### PR TITLE
Use TL_H2D_T_WIDTH for tie off width

### DIFF
--- a/src/integration/rtl/caliptra_ss_top.sv
+++ b/src/integration/rtl/caliptra_ss_top.sv
@@ -1253,7 +1253,7 @@ module caliptra_ss_top
         .core_axi_rd_req            (cptra_ss_otp_core_axi_rd_req_i),
         .core_axi_rd_rsp            (cptra_ss_otp_core_axi_rd_rsp_o),
 
-        .prim_tl_i                  (107'd0),
+        .prim_tl_i                  ({tlul_pkg::TL_H2D_T_WIDTH{1'b0}}),
         .prim_tl_o                  (),
         .prim_generic_otp_outputs_i (cptra_ss_fuse_macro_outputs_i),
         .prim_generic_otp_inputs_o  (cptra_ss_fuse_macro_inputs_o),

--- a/src/tlul/rtl/tlul_pkg.sv
+++ b/src/tlul/rtl/tlul_pkg.sv
@@ -103,6 +103,8 @@ package tlul_pkg;
     logic                         d_ready;
   } tl_h2d_t;
 
+  parameter int TL_H2D_T_WIDTH = $bits(tl_h2d_t);
+
   // The choice of all 1's as the blanked value is deliberate.
   // It is assumed that most security features of the design are opt-in instead
   // of opt-out.


### PR DESCRIPTION
This PR Introduces a parameterized tie off width based on the `TL_H2D_T_WIDTH` parameter.
Addresses #2 