### PR TITLE
Expose CSS_IDCODE_VALUE parameter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "third_party/caliptra-rtl"]
 	path = third_party/caliptra-rtl
-	url = https://github.com/chipsalliance/caliptra-rtl.git
-	branch = patch_v2.0
+	url = https://github.com/antmicro/caliptra-rtl.git
+	branch = 87158-expose-css-idcode
 [submodule "third_party/i3c-core"]
 	path = third_party/i3c-core
 	url = https://github.com/antmicro/i3c-core.git

--- a/src/integration/rtl/caliptra_ss_top.sv
+++ b/src/integration/rtl/caliptra_ss_top.sv
@@ -451,7 +451,9 @@ module caliptra_ss_top
     assign cptra_ss_cptra_generic_fw_exec_ctrl_o = cptra_ss_cptra_generic_fw_exec_ctrl_internal[127:3];
     assign cptra_ss_cptra_generic_fw_exec_ctrl_2_mcu_o = cptra_ss_cptra_generic_fw_exec_ctrl_internal[2];
 
-    caliptra_top caliptra_top_dut (
+    caliptra_top #(
+        .CSS_IDCODE_VALUE(CSS_IDCODE_VALUE)
+    ) caliptra_top_dut (
         .clk                        (cptra_ss_clk_i),
         .cptra_pwrgood              (cptra_ss_pwrgood_i),
         .cptra_rst_b                (cptra_ss_mci_cptra_rst_b_i),


### PR DESCRIPTION
Fixes #3 

This PR bumps the `caliptra-rtl` submodule to a version based on [v2.0.2](https://github.com/chipsalliance/caliptra-rtl/releases/tag/v2.0.2) tag that exposes the `CSS_IDCODE_VALUE` parameter in `caliptra_top.sv` and below. The change comes into use in `src/integration/rtl/caliptra_ss_top.sv` where we pass this parameter to the `caliptra_top` instance