### PR TITLE
Update peakrdl generated code to ifdef simulation only code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "third_party/caliptra-rtl"]
 	path = third_party/caliptra-rtl
 	url = https://github.com/antmicro/caliptra-rtl.git
-	branch = 87158-expose-css-idcode
+	branch = peakrdl-ifdef
 [submodule "third_party/i3c-core"]
 	path = third_party/i3c-core
 	url = https://github.com/antmicro/i3c-core.git

--- a/src/mci/rtl/mcu_mbox_csr.sv
+++ b/src/mci/rtl/mcu_mbox_csr.sv
@@ -64,10 +64,12 @@ module mcu_mbox_csr (
         end else begin
             if(external_req & ~external_wr_ack & ~external_rd_ack) external_pending <= '1;
             else if(external_wr_ack | external_rd_ack) external_pending <= '0;
-            assert(!external_wr_ack || (external_pending | external_req))
-                else $error("An external wr_ack strobe was asserted when no external request was active");
-            assert(!external_rd_ack || (external_pending | external_req))
-                else $error("An external rd_ack strobe was asserted when no external request was active");
+            `ifndef SYNTHESIS
+                assert(!external_wr_ack || (external_pending | external_req))
+                    else $error("An external wr_ack strobe was asserted when no external request was active");
+                assert(!external_rd_ack || (external_pending | external_req))
+                    else $error("An external rd_ack strobe was asserted when no external request was active");
+            `endif
         end
     end
 


### PR DESCRIPTION
This PR addresses #12

The code was generated with peakrdl-regblock version 0.21.0 with the https://github.com/SystemRDL/PeakRDL-regblock/commit/faa57c93 commit applied on top. The PR bumps caliptra-rtl in order to bump the adams-bridge submodules, as some peakrdl-regblock generated code was present there