### PR TITLE
Remove coverpoints to align with updated OTP

### DIFF
--- a/src/fuse_ctrl/coverage/fuse_ctrl_cov_if.sv
+++ b/src/fuse_ctrl/coverage/fuse_ctrl_cov_if.sv
@@ -87,17 +87,7 @@ interface fuse_ctrl_cov_if
       SecretProdPartition3Digest_cp: coverpoint `FC_MEM[SecretProdPartition3DigestOffset/2] { bins Fuse = { [1:$] }; }
       // SW_MANUF_PARTITION
       CptraCoreAntiRollbackDisable_cp:      coverpoint `FC_MEM[CptraCoreAntiRollbackDisableOffset/2]      { bins Fuse = { [1:$] }; }
-      CptraCoreIdevidCertIdevidAttr_cp:     coverpoint `FC_MEM[CptraCoreIdevidCertIdevidAttrOffset/2]     { bins Fuse = { [1:$] }; }
-      CptraCoreIdevidManufHsmIdentifier_cp: coverpoint `FC_MEM[CptraCoreIdevidManufHsmIdentifierOffset/2] { bins Fuse = { [1:$] }; }                                                                                
-      CptraCoreSocSteppingId_cp:            coverpoint `FC_MEM[CptraCoreSocSteppingIdOffset/2]            { bins Fuse = { [1:$] }; }
       CptraSsProdDebugUnlockPks0_cp:        coverpoint `FC_MEM[CptraSsProdDebugUnlockPks0Offset/2]        { bins Fuse = { [1:$] }; }
-      CptraSsProdDebugUnlockPks1_cp:        coverpoint `FC_MEM[CptraSsProdDebugUnlockPks1Offset/2]        { bins Fuse = { [1:$] }; }
-      CptraSsProdDebugUnlockPks2_cp:        coverpoint `FC_MEM[CptraSsProdDebugUnlockPks2Offset/2]        { bins Fuse = { [1:$] }; }
-      CptraSsProdDebugUnlockPks3_cp:        coverpoint `FC_MEM[CptraSsProdDebugUnlockPks3Offset/2]        { bins Fuse = { [1:$] }; }
-      CptraSsProdDebugUnlockPks4_cp:        coverpoint `FC_MEM[CptraSsProdDebugUnlockPks4Offset/2]        { bins Fuse = { [1:$] }; }
-      CptraSsProdDebugUnlockPks5_cp:        coverpoint `FC_MEM[CptraSsProdDebugUnlockPks5Offset/2]        { bins Fuse = { [1:$] }; }  
-      CptraSsProdDebugUnlockPks6_cp:        coverpoint `FC_MEM[CptraSsProdDebugUnlockPks6Offset/2]        { bins Fuse = { [1:$] }; }
-      CptraSsProdDebugUnlockPks7_cp:        coverpoint `FC_MEM[CptraSsProdDebugUnlockPks7Offset/2]        { bins Fuse = { [1:$] }; }
       SwManufPartitionDigest_cp:            coverpoint `FC_MEM[SwManufPartitionDigestOffset/2]            { bins Fuse = { [1:$] }; }
       // SECRET_LC_TRANSITION_PARTITION
       CptraSsTestUnlockToken1_cp:           coverpoint `FC_MEM[CptraSsTestUnlockToken1Offset/2]           { bins Fuse = { [1:$] }; }
@@ -117,9 +107,6 @@ interface fuse_ctrl_cov_if
       CptraCoreRuntimeSvn_cp:        coverpoint `FC_MEM[CptraCoreRuntimeSvnOffset/2]        { bins Fuse = { [1:$] }; }
       CptraCoreSocManifestSvn_cp:    coverpoint `FC_MEM[CptraCoreSocManifestSvnOffset/2]    { bins Fuse = { [1:$] }; }
       CptraCoreSocManifestMaxSvn_cp: coverpoint `FC_MEM[CptraCoreSocManifestMaxSvnOffset/2] { bins Fuse = { [1:$] }; }
-      // VENDOR_TEST_PARTITION
-      VendorTest_cp:                coverpoint `FC_MEM[VendorTestOffset/2]                { bins Fuse = { [1:$] }; }
-      VendorTestPartitionDigest_cp: coverpoint `FC_MEM[VendorTestPartitionDigestOffset/2] { bins Fuse = { [1:$] }; }
       // VENDOR_HASHES_MANUF_PARTITION
       CptraCoreVendorPkHash0_cp:           coverpoint `FC_MEM[CptraCoreVendorPkHash0Offset/2]           { bins Fuse = { [1:$] }; }
       CptraCorePqcKeyType0_cp:             coverpoint `FC_MEM[CptraCorePqcKeyType0Offset/2]             { bins Fuse = { [1:$] }; }
@@ -127,34 +114,6 @@ interface fuse_ctrl_cov_if
       // VENDOR_HASHES_PROD_PARTITION
       CptraCoreVendorPkHash1_cp:          coverpoint `FC_MEM[CptraCoreVendorPkHash1Offset/2]          { bins Fuse = { [1:$] }; }
       CptraCorePqcKeyType1_cp:            coverpoint `FC_MEM[CptraCorePqcKeyType1Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreVendorPkHash2_cp:          coverpoint `FC_MEM[CptraCoreVendorPkHash2Offset/2]          { bins Fuse = { [1:$] }; }
-      CptraCorePqcKeyType2_cp:            coverpoint `FC_MEM[CptraCorePqcKeyType2Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreVendorPkHash3_cp:          coverpoint `FC_MEM[CptraCoreVendorPkHash3Offset/2]          { bins Fuse = { [1:$] }; }
-      CptraCorePqcKeyType3_cp:            coverpoint `FC_MEM[CptraCorePqcKeyType3Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreVendorPkHash4_cp:          coverpoint `FC_MEM[CptraCoreVendorPkHash4Offset/2]          { bins Fuse = { [1:$] }; }
-      CptraCorePqcKeyType4_cp:            coverpoint `FC_MEM[CptraCorePqcKeyType4Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreVendorPkHash5_cp:          coverpoint `FC_MEM[CptraCoreVendorPkHash5Offset/2]          { bins Fuse = { [1:$] }; }
-      CptraCorePqcKeyType5_cp:            coverpoint `FC_MEM[CptraCorePqcKeyType5Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreVendorPkHash6_cp:          coverpoint `FC_MEM[CptraCoreVendorPkHash6Offset/2]          { bins Fuse = { [1:$] }; }
-      CptraCorePqcKeyType6_cp:            coverpoint `FC_MEM[CptraCorePqcKeyType6Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreVendorPkHash7_cp:          coverpoint `FC_MEM[CptraCoreVendorPkHash7Offset/2]          { bins Fuse = { [1:$] }; }
-      CptraCorePqcKeyType7_cp:            coverpoint `FC_MEM[CptraCorePqcKeyType7Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreVendorPkHash8_cp:          coverpoint `FC_MEM[CptraCoreVendorPkHash8Offset/2]          { bins Fuse = { [1:$] }; }
-      CptraCorePqcKeyType8_cp:            coverpoint `FC_MEM[CptraCorePqcKeyType8Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreVendorPkHash9_cp:          coverpoint `FC_MEM[CptraCoreVendorPkHash9Offset/2]          { bins Fuse = { [1:$] }; }
-      CptraCorePqcKeyType9_cp:            coverpoint `FC_MEM[CptraCorePqcKeyType9Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreVendorPkHash10_cp:         coverpoint `FC_MEM[CptraCoreVendorPkHash10Offset/2]         { bins Fuse = { [1:$] }; }
-      CptraCorePqcKeyType10_cp:           coverpoint `FC_MEM[CptraCorePqcKeyType10Offset/2]           { bins Fuse = { [1:$] }; }
-      CptraCoreVendorPkHash11_cp:         coverpoint `FC_MEM[CptraCoreVendorPkHash11Offset/2]         { bins Fuse = { [1:$] }; }
-      CptraCorePqcKeyType11_cp:           coverpoint `FC_MEM[CptraCorePqcKeyType11Offset/2]           { bins Fuse = { [1:$] }; }
-      CptraCoreVendorPkHash12_cp:         coverpoint `FC_MEM[CptraCoreVendorPkHash12Offset/2]         { bins Fuse = { [1:$] }; }
-      CptraCorePqcKeyType12_cp:           coverpoint `FC_MEM[CptraCorePqcKeyType12Offset/2]           { bins Fuse = { [1:$] }; }
-      CptraCoreVendorPkHash13_cp:         coverpoint `FC_MEM[CptraCoreVendorPkHash13Offset/2]         { bins Fuse = { [1:$] }; }
-      CptraCorePqcKeyType13_cp:           coverpoint `FC_MEM[CptraCorePqcKeyType13Offset/2]           { bins Fuse = { [1:$] }; }
-      CptraCoreVendorPkHash14_cp:         coverpoint `FC_MEM[CptraCoreVendorPkHash14Offset/2]         { bins Fuse = { [1:$] }; }
-      CptraCorePqcKeyType14_cp:           coverpoint `FC_MEM[CptraCorePqcKeyType14Offset/2]           { bins Fuse = { [1:$] }; }
-      CptraCoreVendorPkHash15_cp:         coverpoint `FC_MEM[CptraCoreVendorPkHash15Offset/2]         { bins Fuse = { [1:$] }; }
-      CptraCorePqcKeyType15_cp:           coverpoint `FC_MEM[CptraCorePqcKeyType15Offset/2]           { bins Fuse = { [1:$] }; }
       CptraCoreVendorPkHashValid_cp:      coverpoint `FC_MEM[CptraCoreVendorPkHashValidOffset/2]      { bins Fuse = { [1:$] }; }
       VendorHashesProdPartitionDigest_cp: coverpoint `FC_MEM[VendorHashesProdPartitionDigestOffset/2] { bins Fuse = { [1:$] }; }
       // VENDOR_REVOCATIONS_PROD_PARTITION
@@ -164,85 +123,13 @@ interface fuse_ctrl_cov_if
       CptraCoreEccRevocation1_cp:              coverpoint `FC_MEM[CptraCoreEccRevocation1Offset/2]              { bins Fuse = { [1:$] }; }
       CptraCoreLmsRevocation1_cp:              coverpoint `FC_MEM[CptraCoreLmsRevocation1Offset/2]              { bins Fuse = { [1:$] }; }
       CptraCoreMldsaRevocation1_cp:            coverpoint `FC_MEM[CptraCoreMldsaRevocation1Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreEccRevocation2_cp:              coverpoint `FC_MEM[CptraCoreEccRevocation2Offset/2]              { bins Fuse = { [1:$] }; }
-      CptraCoreLmsRevocation2_cp:              coverpoint `FC_MEM[CptraCoreLmsRevocation2Offset/2]              { bins Fuse = { [1:$] }; }
-      CptraCoreMldsaRevocation2_cp:            coverpoint `FC_MEM[CptraCoreMldsaRevocation2Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreEccRevocation3_cp:              coverpoint `FC_MEM[CptraCoreEccRevocation3Offset/2]              { bins Fuse = { [1:$] }; }
-      CptraCoreLmsRevocation3_cp:              coverpoint `FC_MEM[CptraCoreLmsRevocation3Offset/2]              { bins Fuse = { [1:$] }; }
-      CptraCoreMldsaRevocation3_cp:            coverpoint `FC_MEM[CptraCoreMldsaRevocation3Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreEccRevocation4_cp:              coverpoint `FC_MEM[CptraCoreEccRevocation4Offset/2]              { bins Fuse = { [1:$] }; }
-      CptraCoreLmsRevocation4_cp:              coverpoint `FC_MEM[CptraCoreLmsRevocation4Offset/2]              { bins Fuse = { [1:$] }; }
-      CptraCoreMldsaRevocation4_cp:            coverpoint `FC_MEM[CptraCoreMldsaRevocation4Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreEccRevocation5_cp:              coverpoint `FC_MEM[CptraCoreEccRevocation5Offset/2]              { bins Fuse = { [1:$] }; }
-      CptraCoreLmsRevocation5_cp:              coverpoint `FC_MEM[CptraCoreLmsRevocation5Offset/2]              { bins Fuse = { [1:$] }; }
-      CptraCoreMldsaRevocation5_cp:            coverpoint `FC_MEM[CptraCoreMldsaRevocation5Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreEccRevocation6_cp:              coverpoint `FC_MEM[CptraCoreEccRevocation6Offset/2]              { bins Fuse = { [1:$] }; }
-      CptraCoreLmsRevocation6_cp:              coverpoint `FC_MEM[CptraCoreLmsRevocation6Offset/2]              { bins Fuse = { [1:$] }; }
-      CptraCoreMldsaRevocation6_cp:            coverpoint `FC_MEM[CptraCoreMldsaRevocation6Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreEccRevocation7_cp:              coverpoint `FC_MEM[CptraCoreEccRevocation7Offset/2]              { bins Fuse = { [1:$] }; }
-      CptraCoreLmsRevocation7_cp:              coverpoint `FC_MEM[CptraCoreLmsRevocation7Offset/2]              { bins Fuse = { [1:$] }; }
-      CptraCoreMldsaRevocation7_cp:            coverpoint `FC_MEM[CptraCoreMldsaRevocation7Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreEccRevocation8_cp:              coverpoint `FC_MEM[CptraCoreEccRevocation8Offset/2]              { bins Fuse = { [1:$] }; }
-      CptraCoreLmsRevocation8_cp:              coverpoint `FC_MEM[CptraCoreLmsRevocation8Offset/2]              { bins Fuse = { [1:$] }; }
-      CptraCoreMldsaRevocation8_cp:            coverpoint `FC_MEM[CptraCoreMldsaRevocation8Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreEccRevocation9_cp:              coverpoint `FC_MEM[CptraCoreEccRevocation9Offset/2]              { bins Fuse = { [1:$] }; }
-      CptraCoreLmsRevocation9_cp:              coverpoint `FC_MEM[CptraCoreLmsRevocation9Offset/2]              { bins Fuse = { [1:$] }; }
-      CptraCoreMldsaRevocation9_cp:            coverpoint `FC_MEM[CptraCoreMldsaRevocation9Offset/2]            { bins Fuse = { [1:$] }; }
-      CptraCoreEccRevocation10_cp:             coverpoint `FC_MEM[CptraCoreEccRevocation10Offset/2]             { bins Fuse = { [1:$] }; }
-      CptraCoreLmsRevocation10_cp:             coverpoint `FC_MEM[CptraCoreLmsRevocation10Offset/2]             { bins Fuse = { [1:$] }; }
-      CptraCoreMldsaRevocation10_cp:           coverpoint `FC_MEM[CptraCoreMldsaRevocation10Offset/2]           { bins Fuse = { [1:$] }; }
-      CptraCoreEccRevocation11_cp:             coverpoint `FC_MEM[CptraCoreEccRevocation11Offset/2]             { bins Fuse = { [1:$] }; }
-      CptraCoreLmsRevocation11_cp:             coverpoint `FC_MEM[CptraCoreLmsRevocation11Offset/2]             { bins Fuse = { [1:$] }; }
-      CptraCoreMldsaRevocation11_cp:           coverpoint `FC_MEM[CptraCoreMldsaRevocation11Offset/2]           { bins Fuse = { [1:$] }; }
-      CptraCoreEccRevocation12_cp:             coverpoint `FC_MEM[CptraCoreEccRevocation12Offset/2]             { bins Fuse = { [1:$] }; }
-      CptraCoreLmsRevocation12_cp:             coverpoint `FC_MEM[CptraCoreLmsRevocation12Offset/2]             { bins Fuse = { [1:$] }; }
-      CptraCoreMldsaRevocation12_cp:           coverpoint `FC_MEM[CptraCoreMldsaRevocation12Offset/2]           { bins Fuse = { [1:$] }; }
-      CptraCoreEccRevocation13_cp:             coverpoint `FC_MEM[CptraCoreEccRevocation13Offset/2]             { bins Fuse = { [1:$] }; }
-      CptraCoreLmsRevocation13_cp:             coverpoint `FC_MEM[CptraCoreLmsRevocation13Offset/2]             { bins Fuse = { [1:$] }; }
-      CptraCoreMldsaRevocation13_cp:           coverpoint `FC_MEM[CptraCoreMldsaRevocation13Offset/2]           { bins Fuse = { [1:$] }; }
-      CptraCoreEccRevocation14_cp:             coverpoint `FC_MEM[CptraCoreEccRevocation14Offset/2]             { bins Fuse = { [1:$] }; }
-      CptraCoreLmsRevocation14_cp:             coverpoint `FC_MEM[CptraCoreLmsRevocation14Offset/2]             { bins Fuse = { [1:$] }; }
-      CptraCoreMldsaRevocation14_cp:           coverpoint `FC_MEM[CptraCoreMldsaRevocation14Offset/2]           { bins Fuse = { [1:$] }; }
-      CptraCoreEccRevocation15_cp:             coverpoint `FC_MEM[CptraCoreEccRevocation15Offset/2]             { bins Fuse = { [1:$] }; }
-      CptraCoreLmsRevocation15_cp:             coverpoint `FC_MEM[CptraCoreLmsRevocation15Offset/2]             { bins Fuse = { [1:$] }; }
-      CptraCoreMldsaRevocation15_cp:           coverpoint `FC_MEM[CptraCoreMldsaRevocation15Offset/2]           { bins Fuse = { [1:$] }; }
       VendorRevocationsProdPartitionDigest_cp: coverpoint `FC_MEM[VendorRevocationsProdPartitionDigestOffset/2] { bins Fuse = { [1:$] }; }
-      // VENDOR_SECRET_PROD_PARTITION
-      CptraSsVendorSpecificSecretFuse0_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificSecretFuse0Offset/2]  { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificSecretFuse1_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificSecretFuse1Offset/2]  { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificSecretFuse2_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificSecretFuse2Offset/2]  { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificSecretFuse3_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificSecretFuse3Offset/2]  { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificSecretFuse4_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificSecretFuse4Offset/2]  { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificSecretFuse5_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificSecretFuse5Offset/2]  { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificSecretFuse6_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificSecretFuse6Offset/2]  { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificSecretFuse7_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificSecretFuse7Offset/2]  { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificSecretFuse8_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificSecretFuse8Offset/2]  { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificSecretFuse9_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificSecretFuse9Offset/2]  { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificSecretFuse10_cp: coverpoint `FC_MEM[CptraSsVendorSpecificSecretFuse10Offset/2] { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificSecretFuse11_cp: coverpoint `FC_MEM[CptraSsVendorSpecificSecretFuse11Offset/2] { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificSecretFuse12_cp: coverpoint `FC_MEM[CptraSsVendorSpecificSecretFuse12Offset/2] { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificSecretFuse13_cp: coverpoint `FC_MEM[CptraSsVendorSpecificSecretFuse13Offset/2] { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificSecretFuse14_cp: coverpoint `FC_MEM[CptraSsVendorSpecificSecretFuse14Offset/2] { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificSecretFuse15_cp: coverpoint `FC_MEM[CptraSsVendorSpecificSecretFuse15Offset/2] { bins Fuse = { [1:$] }; }
-      VendorSecretProdPartitionDigest_cp:   coverpoint `FC_MEM[VendorSecretProdPartitionDigestOffset/2]   { bins Fuse = { [1:$] }; }
       // VENDOR_NON_SECRET_PROD_PARTITION
       CptraSsVendorSpecificNonSecretFuse0_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificNonSecretFuse0Offset/2]  { bins Fuse = { [1:$] }; }
       CptraSsVendorSpecificNonSecretFuse1_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificNonSecretFuse1Offset/2]  { bins Fuse = { [1:$] }; }
       CptraSsVendorSpecificNonSecretFuse2_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificNonSecretFuse2Offset/2]  { bins Fuse = { [1:$] }; }
       CptraSsVendorSpecificNonSecretFuse3_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificNonSecretFuse3Offset/2]  { bins Fuse = { [1:$] }; }
       CptraSsVendorSpecificNonSecretFuse4_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificNonSecretFuse4Offset/2]  { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificNonSecretFuse5_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificNonSecretFuse5Offset/2]  { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificNonSecretFuse6_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificNonSecretFuse6Offset/2]  { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificNonSecretFuse7_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificNonSecretFuse7Offset/2]  { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificNonSecretFuse8_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificNonSecretFuse8Offset/2]  { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificNonSecretFuse9_cp:  coverpoint `FC_MEM[CptraSsVendorSpecificNonSecretFuse9Offset/2]  { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificNonSecretFuse10_cp: coverpoint `FC_MEM[CptraSsVendorSpecificNonSecretFuse10Offset/2] { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificNonSecretFuse11_cp: coverpoint `FC_MEM[CptraSsVendorSpecificNonSecretFuse11Offset/2] { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificNonSecretFuse12_cp: coverpoint `FC_MEM[CptraSsVendorSpecificNonSecretFuse12Offset/2] { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificNonSecretFuse13_cp: coverpoint `FC_MEM[CptraSsVendorSpecificNonSecretFuse13Offset/2] { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificNonSecretFuse14_cp: coverpoint `FC_MEM[CptraSsVendorSpecificNonSecretFuse14Offset/2] { bins Fuse = { [1:$] }; }
-      CptraSsVendorSpecificNonSecretFuse15_cp: coverpoint `FC_MEM[CptraSsVendorSpecificNonSecretFuse15Offset/2] { bins Fuse = { [1:$] }; }
-      VendorNonSecretProdPartitionDigest_cp:   coverpoint `FC_MEM[VendorNonSecretProdPartitionDigestOffset/2]   { bins Fuse = { [1:$] }; }
       // LIFE_CYCLE
       LcTransitionCnt_cp: coverpoint `FC_MEM[LcTransitionCntOffset/2] { bins Fuse = { [1:$] }; }
       LcState_cp:         coverpoint `FC_MEM[LcStateOffset/2]         { bins Fuse = { [1:$] }; }
@@ -333,11 +220,11 @@ interface fuse_ctrl_cov_if
                 OTP_CTRL_ERR_CODE_5_OFFSET, OTP_CTRL_ERR_CODE_6_OFFSET, OTP_CTRL_ERR_CODE_7_OFFSET, OTP_CTRL_ERR_CODE_8_OFFSET,
                 OTP_CTRL_ERR_CODE_9_OFFSET, OTP_CTRL_ERR_CODE_10_OFFSET, OTP_CTRL_ERR_CODE_11_OFFSET, OTP_CTRL_ERR_CODE_12_OFFSET,
                 OTP_CTRL_ERR_CODE_13_OFFSET, OTP_CTRL_ERR_CODE_14_OFFSET, OTP_CTRL_ERR_CODE_15_OFFSET, OTP_CTRL_ERR_CODE_16_OFFSET,
-                OTP_CTRL_ERR_CODE_17_OFFSET, OTP_CTRL_DIRECT_ACCESS_REGWEN_OFFSET, OTP_CTRL_DIRECT_ACCESS_CMD_OFFSET, OTP_CTRL_DIRECT_ACCESS_ADDRESS_OFFSET,
+                OTP_CTRL_DIRECT_ACCESS_REGWEN_OFFSET, OTP_CTRL_DIRECT_ACCESS_CMD_OFFSET, OTP_CTRL_DIRECT_ACCESS_ADDRESS_OFFSET,
                 OTP_CTRL_DIRECT_ACCESS_WDATA_0_OFFSET, OTP_CTRL_DIRECT_ACCESS_WDATA_1_OFFSET, OTP_CTRL_DIRECT_ACCESS_RDATA_0_OFFSET, OTP_CTRL_DIRECT_ACCESS_RDATA_1_OFFSET,
                 OTP_CTRL_CHECK_TRIGGER_REGWEN_OFFSET, OTP_CTRL_CHECK_TRIGGER_OFFSET, OTP_CTRL_CHECK_REGWEN_OFFSET, OTP_CTRL_CHECK_TIMEOUT_OFFSET,
                 OTP_CTRL_INTEGRITY_CHECK_PERIOD_OFFSET, OTP_CTRL_CONSISTENCY_CHECK_PERIOD_OFFSET, OTP_CTRL_SW_MANUF_PARTITION_READ_LOCK_OFFSET,
-                OTP_CTRL_SVN_PARTITION_READ_LOCK_OFFSET, OTP_CTRL_VENDOR_TEST_PARTITION_READ_LOCK_OFFSET, OTP_CTRL_VENDOR_HASHES_MANUF_PARTITION_READ_LOCK_OFFSET,
+                OTP_CTRL_SVN_PARTITION_READ_LOCK_OFFSET, OTP_CTRL_VENDOR_HASHES_MANUF_PARTITION_READ_LOCK_OFFSET,
                 OTP_CTRL_VENDOR_HASHES_PROD_PARTITION_READ_LOCK_OFFSET, OTP_CTRL_VENDOR_REVOCATIONS_PROD_PARTITION_READ_LOCK_OFFSET,
                 OTP_CTRL_VENDOR_NON_SECRET_PROD_PARTITION_READ_LOCK_OFFSET, OTP_CTRL_VENDOR_PK_HASH_VOLATILE_LOCK_OFFSET,
                 OTP_CTRL_SW_TEST_UNLOCK_PARTITION_DIGEST_0_OFFSET, OTP_CTRL_SW_TEST_UNLOCK_PARTITION_DIGEST_1_OFFSET,
@@ -348,12 +235,9 @@ interface fuse_ctrl_cov_if
                 OTP_CTRL_SECRET_PROD_PARTITION_3_DIGEST_0_OFFSET, OTP_CTRL_SECRET_PROD_PARTITION_3_DIGEST_1_OFFSET,
                 OTP_CTRL_SW_MANUF_PARTITION_DIGEST_0_OFFSET, OTP_CTRL_SW_MANUF_PARTITION_DIGEST_1_OFFSET,
                 OTP_CTRL_SECRET_LC_TRANSITION_PARTITION_DIGEST_0_OFFSET, OTP_CTRL_SECRET_LC_TRANSITION_PARTITION_DIGEST_1_OFFSET,
-                OTP_CTRL_VENDOR_TEST_PARTITION_DIGEST_0_OFFSET, OTP_CTRL_VENDOR_TEST_PARTITION_DIGEST_1_OFFSET,
                 OTP_CTRL_VENDOR_HASHES_MANUF_PARTITION_DIGEST_0_OFFSET, OTP_CTRL_VENDOR_HASHES_MANUF_PARTITION_DIGEST_1_OFFSET,
                 OTP_CTRL_VENDOR_HASHES_PROD_PARTITION_DIGEST_0_OFFSET, OTP_CTRL_VENDOR_HASHES_PROD_PARTITION_DIGEST_1_OFFSET,
-                OTP_CTRL_VENDOR_REVOCATIONS_PROD_PARTITION_DIGEST_0_OFFSET, OTP_CTRL_VENDOR_REVOCATIONS_PROD_PARTITION_DIGEST_1_OFFSET,
-                OTP_CTRL_VENDOR_SECRET_PROD_PARTITION_DIGEST_0_OFFSET, OTP_CTRL_VENDOR_SECRET_PROD_PARTITION_DIGEST_1_OFFSET,
-                OTP_CTRL_VENDOR_NON_SECRET_PROD_PARTITION_DIGEST_0_OFFSET, OTP_CTRL_VENDOR_NON_SECRET_PROD_PARTITION_DIGEST_1_OFFSET
+                OTP_CTRL_VENDOR_REVOCATIONS_PROD_PARTITION_DIGEST_0_OFFSET, OTP_CTRL_VENDOR_REVOCATIONS_PROD_PARTITION_DIGEST_1_OFFSET
             };
         }
 
@@ -365,7 +249,7 @@ interface fuse_ctrl_cov_if
                 OTP_CTRL_DIRECT_ACCESS_WDATA_0_OFFSET, OTP_CTRL_DIRECT_ACCESS_WDATA_1_OFFSET,
                 OTP_CTRL_CHECK_TRIGGER_REGWEN_OFFSET, OTP_CTRL_CHECK_TRIGGER_OFFSET, OTP_CTRL_CHECK_REGWEN_OFFSET, OTP_CTRL_CHECK_TIMEOUT_OFFSET,
                 OTP_CTRL_INTEGRITY_CHECK_PERIOD_OFFSET, OTP_CTRL_CONSISTENCY_CHECK_PERIOD_OFFSET, OTP_CTRL_SW_MANUF_PARTITION_READ_LOCK_OFFSET,
-                OTP_CTRL_SVN_PARTITION_READ_LOCK_OFFSET, OTP_CTRL_VENDOR_TEST_PARTITION_READ_LOCK_OFFSET, OTP_CTRL_VENDOR_HASHES_MANUF_PARTITION_READ_LOCK_OFFSET,
+                OTP_CTRL_SVN_PARTITION_READ_LOCK_OFFSET, OTP_CTRL_VENDOR_HASHES_MANUF_PARTITION_READ_LOCK_OFFSET,
                 OTP_CTRL_VENDOR_HASHES_PROD_PARTITION_READ_LOCK_OFFSET, OTP_CTRL_VENDOR_REVOCATIONS_PROD_PARTITION_READ_LOCK_OFFSET,
                 OTP_CTRL_VENDOR_NON_SECRET_PROD_PARTITION_READ_LOCK_OFFSET, OTP_CTRL_VENDOR_PK_HASH_VOLATILE_LOCK_OFFSET
             };

--- a/src/integration/testbench/caliptra_ss_top_tb.sv
+++ b/src/integration/testbench/caliptra_ss_top_tb.sv
@@ -1514,9 +1514,7 @@ module caliptra_ss_top_tb
         .TestCtrlWidth    ( otp_ctrl_pkg::OtpTestCtrlWidth    ),
         .TestStatusWidth  ( otp_ctrl_pkg::OtpTestStatusWidth  ),
         .TestVectWidth    ( otp_ctrl_pkg::OtpTestVectWidth    ),
-        .MemInitFile      ("otp-img.2048.vmem"                  ),
-        .VendorTestOffset ( otp_ctrl_reg_pkg::VendorTestOffset    ),
-        .VendorTestSize   ( otp_ctrl_reg_pkg::VendorTestSize      )
+        .MemInitFile      ("otp-img.2048.vmem"                  )
     ) u_otp (
         // Clock and Reset
         .clk_i          ( cptra_ss_fuse_macro_inputs_tb.clk_i ),

--- a/src/integration/testbench/fc_lcc_tb_services.sv
+++ b/src/integration/testbench/fc_lcc_tb_services.sv
@@ -247,25 +247,23 @@ module fc_lcc_tb_services (
   //-------------------------------------------------------------------------
 
   reg fault_active_q;
-  reg [15:0] faulted_word_q [0:6];
+  reg [15:0] faulted_word_q [0:5];
 
-  localparam int partition_offsets [0:6] = '{
+  localparam int partition_offsets [0:5] = '{
     SecretManufPartitionOffset/2,
     SecretProdPartition0Offset/2,
     SecretProdPartition1Offset/2,
     SecretProdPartition2Offset/2,
     SecretProdPartition3Offset/2,
-    SecretLcTransitionPartitionOffset/2,
-    VendorSecretProdPartitionOffset/2
+    SecretLcTransitionPartitionOffset/2
   };
-  localparam int partition_digests [0:6] = '{
+  localparam int partition_digests [0:5] = '{
     SecretManufPartitionDigestOffset/2,
     SecretProdPartition0DigestOffset/2,
     SecretProdPartition1DigestOffset/2,
     SecretProdPartition2DigestOffset/2,
     SecretProdPartition3DigestOffset/2,
-    SecretLcTransitionPartitionDigestOffset/2,
-    VendorSecretProdPartitionDigestOffset/2
+    SecretLcTransitionPartitionDigestOffset/2
   };
 
   always_ff @(posedge clk or negedge cptra_rst_b) begin
@@ -279,7 +277,7 @@ module fc_lcc_tb_services (
   end
 
   generate
-  for (genvar i = 0; i < 7; i++) begin
+  for (genvar i = 0; i < 6; i++) begin
     always_ff @(posedge clk or negedge cptra_rst_b) begin
       if (!cptra_rst_b) begin
         faulted_word_q[i] <= '0;
@@ -298,7 +296,7 @@ module fc_lcc_tb_services (
   endgenerate
 
   generate
-  for (genvar i = 0; i < 7; i++) begin
+  for (genvar i = 0; i < 6; i++) begin
     always_comb begin
       if (fault_active_q) begin
         force `FC_MEM[partition_offsets[i]][15:0] = faulted_word_q[i];


### PR DESCRIPTION
This MR removes coverpoints that are no longer valid after removing and resize partitions.