### PR TITLE
Axi2tlul extra tests

### DIFF
--- a/src/integration/test_suites/caliptra_ss_fuse_ctrl_invalid_register/caliptra_ss_fuse_ctrl_invalid_register.c
+++ b/src/integration/test_suites/caliptra_ss_fuse_ctrl_invalid_register/caliptra_ss_fuse_ctrl_invalid_register.c
@@ -1,0 +1,101 @@
+//********************************************************************************
+// SPDX-License-Identifier: Apache-2.0
+//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//********************************************************************************
+#include <string.h>
+#include <stdint.h>
+#include <time.h>
+#include <stdlib.h>
+
+#include "soc_address_map.h"
+#include "printf.h"
+#include "riscv_hw_if.h"
+#include "soc_ifc.h"
+#include "caliptra_ss_lc_ctrl_address_map.h"
+#include "caliptra_ss_lib.h"
+#include "fuse_ctrl.h"
+#include "lc_ctrl.h"
+#include "riscv-csr.h"
+
+volatile uint32_t  rst_count = 0;
+volatile uint32_t intr_count = 0;
+
+volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+void nmi_handler (void) {
+    VPRINTF(LOW, "*** Entering NMI Handler ***\n");
+    if (csr_read_mcause() == (0xF0000000 + rst_count)) {
+        intr_count += 1;
+    }
+    rst_count  += 1;
+    SEND_STDOUT_CTRL(TB_CMD_COLD_RESET);
+}
+
+void test_read_invalid_register(void) {
+    VPRINTF(LOW, "============\nMCU: TESTING INVALID OTP CTRL REGISTER READ\n============\n\n");
+
+    // Read outside LCC register space
+    // This should trigger NMI
+    // OTP_CTRL_CSR0 is not routed to the otp prim in the testbench
+    lsu_read_32(SOC_OTP_CTRL_CSR0);
+    for (uint8_t ii = 0; ii < 160; ii++) {
+        __asm__ volatile ("nop"); // Sleep loop as "nop"
+    }
+
+    VPRINTF(LOW, "============\nMCU: TESTING INVALID OTP_CTRL REGISTER READ FINISHED\n============\n\n");
+}
+
+void test_write_invalid_register(void) {
+    VPRINTF(LOW, "============\nMCU: TESTING INVALID OTP_CTRL REGISTER WRITE\n============\n\n");
+
+    // OTP_CTRL_CSR0 is not routed to the otp prim in the testbench
+    lsu_write_32(SOC_OTP_CTRL_CSR0, 0xdeadbeef);
+    for (uint8_t ii = 0; ii < 160; ii++) {
+        __asm__ volatile ("nop"); // Sleep loop as "nop"
+    }
+
+    VPRINTF(LOW, "============\nMCU: TESTING INVALID OTP_CTRL REGISTER WRITE FINISHED\n============\n\n");
+}
+
+void main (void) {
+    VPRINTF(LOW, "=================\nMCU Caliptra Boot Go\n=================\n\n")
+    mcu_cptra_init_d();
+    wait_dai_op_idle(0);
+    lcc_initialization();
+    grant_mcu_for_fc_writes();
+    initialize_otp_controller();
+    lsu_write_32(SOC_MCI_TOP_MCI_REG_MCU_NMI_VECTOR, (uint32_t) (nmi_handler));
+
+    if (rst_count == 0) {
+        test_write_invalid_register();
+    } else if (rst_count == 1) {
+        test_read_invalid_register();
+    }
+
+    for (uint8_t ii = 0; ii < 200; ii++) {
+        __asm__ volatile ("nop"); // Sleep loop as "nop"
+    }
+
+    if (intr_count != 2) {
+        SEND_STDOUT_CTRL(0x01);
+    } else {
+        SEND_STDOUT_CTRL(0xff);
+    }
+}

--- a/src/integration/test_suites/caliptra_ss_fuse_ctrl_invalid_register/caliptra_ss_fuse_ctrl_invalid_register.yml
+++ b/src/integration/test_suites/caliptra_ss_fuse_ctrl_invalid_register/caliptra_ss_fuse_ctrl_invalid_register.yml
@@ -1,0 +1,7 @@
+---
+seed: 1
+testname: caliptra_ss_fuse_ctrl_invalid_register
+pre-exec: |
+  echo "Running pre_exec for [caliptra_ss_fuse_ctrl_invalid_register]"
+  CALIPTRA_ROOT=$CALIPTRA_SS_ROOT/third_party/caliptra-rtl make -f $CALIPTRA_SS_ROOT/third_party/caliptra-rtl/tools/scripts/Makefile CALIPTRA_INTERNAL_TRNG=0 TESTNAME=smoke_test_mbox program.hex
+  make -f $CALIPTRA_SS_ROOT/tools/scripts/Makefile TESTNAME=caliptra_ss_fuse_ctrl_invalid_register mcu_program.hex

--- a/src/integration/test_suites/smoke_test_jtag_prod_dbg/smoke_test_jtag_prod_dbg.tcl
+++ b/src/integration/test_suites/smoke_test_jtag_prod_dbg/smoke_test_jtag_prod_dbg.tcl
@@ -25,6 +25,10 @@ set CPTRA_SECURITY_STATE_REG            0x7D
 set CPTRA_DEBUG_INTENT_REG              0x7F
 set DMI_REG_BOOTFSM_GO_ADDR             0x61
 
+proc kill_sim {} {
+    write_memory 0x21000414 32 0x01 phys
+}
+
 
 # Req Payload
 array set REQ_PAYLOAD {
@@ -129,9 +133,11 @@ if {$success} {
     puts "TAP: PROD DEBUG UNLOCK SUCCESS."
 } elseif {$failure} {
     puts "TAP: PROD DEBUG UNLOCK FAIL."
+    kill_sim
     shutdown error
 } else {
     puts "TAP: Unexpected unlock result. Status: $rsp"
+    kill_sim
     shutdown error
 }
 

--- a/src/integration/test_suites/smoke_test_jtag_prod_dbg/smoke_test_jtag_prod_dbg.yml
+++ b/src/integration/test_suites/smoke_test_jtag_prod_dbg/smoke_test_jtag_prod_dbg.yml
@@ -22,4 +22,6 @@ pre-exec: |
   $CALIPTRA_SS_ROOT/tools/scripts/fuse_ctrl_script/gen_fuse_ctrl_vmem.py --seed ${PLAYBOOK_RANDOM_SEED} --lc-state 17 --lc-state-def $CALIPTRA_SS_ROOT/tools/scripts/fuse_ctrl_script/lc_ctrl_state.hjson --mmap-def $CALIPTRA_SS_ROOT/src/fuse_ctrl/data/otp_ctrl_mmap.hjson --token-configuration $CALIPTRA_SS_ROOT/src/integration/test_suites/smoke_test_jtag_prod_dbg/test_unlock_token.hjson -o otp-img.2048.vmem &&
   CALIPTRA_ROOT=$CALIPTRA_SS_ROOT/third_party/caliptra-rtl make -f $CALIPTRA_SS_ROOT/third_party/caliptra-rtl/tools/scripts/Makefile CALIPTRA_INTERNAL_TRNG=0 TEST_DIR=$CALIPTRA_SS_ROOT/src/integration/test_suites/smoke_test_jtag_prod_dbg TESTNAME=caliptra_rom_prod_dbg program.hex &&
   make -f $CALIPTRA_SS_ROOT/tools/scripts/Makefile TEST_DIR=$CALIPTRA_SS_ROOT/src/integration/test_suites/smoke_test_jtag_prod_dbg TESTNAME=mcu_prod_dbg mcu_program.hex
-
+plusargs:
+# TODO: Change onced test is fixed
+  - '+CLP_MAX_CYCLES=20_000'

--- a/src/integration/test_suites/smoke_test_lcc_invalid_register/smoke_test_lcc_invalid_register.c
+++ b/src/integration/test_suites/smoke_test_lcc_invalid_register/smoke_test_lcc_invalid_register.c
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ## LCC Register Test
+//
+// This test reads and writes all registers in the LCC.
+#include <string.h>
+#include <stdint.h>
+#include <time.h>
+#include <stdlib.h>
+
+#include "soc_address_map.h"
+#include "printf.h"
+#include "riscv_hw_if.h"
+#include "soc_ifc.h"
+#include "caliptra_ss_lc_ctrl_address_map.h"
+#include "caliptra_ss_lib.h"
+#include "fuse_ctrl.h"
+#include "lc_ctrl.h"
+#include "riscv-csr.h"
+
+#define MUBITRUE 0x96
+#define MUBIFALSE 0x69
+
+volatile uint32_t  rst_count = 0;
+volatile uint32_t intr_count = 0;
+
+volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+void nmi_handler (void) {
+    VPRINTF(LOW, "*** Entering NMI Handler ***\n");
+    if (csr_read_mcause() == (0xF0000000 + rst_count)) {
+        intr_count += 1;
+    }
+    rst_count  += 1;
+    SEND_STDOUT_CTRL(TB_CMD_COLD_RESET);
+
+}
+
+void test_read_invalid_register(void) {
+    VPRINTF(LOW, "============\nMCU: TESTING INVALID LCC REGISTER READ\n============\n\n");
+
+    // Read outside LCC register space
+    // This should trigger NMI
+    lsu_read_32(SOC_LC_CTRL_MANUF_STATE_7 + 4);
+    for (uint8_t ii = 0; ii < 160; ii++) {
+        __asm__ volatile ("nop"); // Sleep loop as "nop"
+    }
+
+    VPRINTF(LOW, "============\nMCU: TESTING INVALID LCC REGISTER READ FINISHED\n============\n\n");
+}
+
+void test_write_invalid_register(void) {
+    VPRINTF(LOW, "============\nMCU: TESTING INVALID LCC REGISTER WRITE\n============\n\n");
+
+    lsu_write_32(SOC_LC_CTRL_MANUF_STATE_7_OFFSET + 4, 0xdeadbeef);
+    for (uint8_t ii = 0; ii < 160; ii++) {
+        __asm__ volatile ("nop"); // Sleep loop as "nop"
+    }
+
+    VPRINTF(LOW, "============\nMCU: TESTING INVALID LCC REGISTER WRITE FINISHED\n============\n\n");
+}
+
+void main (void) {
+    VPRINTF(LOW, "=================\nMCU: Caliptra Boot Go\n=================\n\n");
+    mcu_cptra_init_d(.cfg_skip_set_fuse_done=true);
+    lcc_initialization();
+    VPRINTF(LOW, "==============\nMCU: TESTING LCC REGISTERS\n==============\n\n");
+    lsu_write_32(SOC_MCI_TOP_MCI_REG_MCU_NMI_VECTOR, (uint32_t) (nmi_handler));
+
+    if (rst_count == 0) {
+        test_write_invalid_register();
+    } else if (rst_count == 1) {
+        test_read_invalid_register();
+    }
+
+    for (uint8_t ii = 0; ii < 200; ii++) {
+        __asm__ volatile ("nop"); // Sleep loop as "nop"
+    }
+
+    if (intr_count != 2) {
+        SEND_STDOUT_CTRL(0x01);
+    } else {
+        SEND_STDOUT_CTRL(0xff);
+    }
+}

--- a/src/integration/test_suites/smoke_test_lcc_invalid_register/smoke_test_lcc_invalid_register.yml
+++ b/src/integration/test_suites/smoke_test_lcc_invalid_register/smoke_test_lcc_invalid_register.yml
@@ -1,0 +1,7 @@
+---
+seed: 1
+testname: smoke_test_lcc_invalid_register
+pre-exec: |
+  echo "Running pre_exec for [smoke_test_lcc_invalid_register]"
+  CALIPTRA_ROOT=$CALIPTRA_SS_ROOT/third_party/caliptra-rtl make -f $CALIPTRA_SS_ROOT/third_party/caliptra-rtl/tools/scripts/Makefile CALIPTRA_INTERNAL_TRNG=0 TESTNAME=smoke_test_mbox program.hex
+  make -f $CALIPTRA_SS_ROOT/tools/scripts/Makefile TESTNAME=smoke_test_lcc_invalid_register mcu_program.hex


### PR DESCRIPTION
This merge request adds 2 new tests: 
* `caliptra_ss_fuse_ctrl_invalid_register`, 
* `smoke_test_lcc_invalid_register`.

They perform read/write accesses to address that is outside `fuse_ctrl`, or `lcc` register space,
 but still inside their AXI range.
Tests make sure that axi2tlul correctly handles TL-UL to AXI error translation.