### PR TITLE
Add new system bus jtag access test

### DIFF
--- a/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access/caliptra_isr.h
+++ b/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access/caliptra_isr.h
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ---------------------------------------------------------------------
+// File: caliptra_isr.h
+// Description:
+//     Provides function declarations for use by external test files, so
+//     that the ISR functionality may behave like a library.
+//     TODO:
+//     This header file includes inline function definitions for event and
+//     test specific interrupt service behavior, so it should be copied and
+//     modified for each test.
+// ---------------------------------------------------------------------
+
+#ifndef CALIPTRA_ISR_H
+    #define CALIPTRA_ISR_H
+
+#define EN_ISR_PRINTS 1
+
+#include "caliptra_reg.h"
+#include <stdint.h>
+#include "printf.h"
+
+/* --------------- symbols/typedefs --------------- */
+typedef struct {
+    uint32_t doe_error;
+    uint32_t doe_notif;
+    uint32_t ecc_error;
+    uint32_t ecc_notif;
+    uint32_t hmac_error;
+    uint32_t hmac_notif;
+    uint32_t kv_error;
+    uint32_t kv_notif;
+    uint32_t sha512_error;
+    uint32_t sha512_notif;
+    uint32_t sha256_error;
+    uint32_t sha256_notif;
+    uint32_t soc_ifc_error;
+    uint32_t soc_ifc_notif;
+    uint32_t sha512_acc_error;
+    uint32_t sha512_acc_notif;
+    uint32_t mldsa_error;
+    uint32_t mldsa_notif;
+    uint32_t axi_dma_error;
+    uint32_t axi_dma_notif;
+} caliptra_intr_received_s;
+extern volatile caliptra_intr_received_s cptra_intr_rcv;
+
+//////////////////////////////////////////////////////////////////////////////
+// Function Declarations
+//
+
+// Performs all the CSR setup to configure and enable vectored external interrupts
+void init_interrupts(void);
+
+// These inline functions are used to insert event-specific functionality into the
+// otherwise generic ISR that gets laid down by the parameterized macro "nonstd_veer_isr"
+inline void service_doe_error_intr() {return;}
+inline void service_doe_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        printf("bad doe_notif_intr sts:%x\n", sts);
+        printf("%c", 0x1);
+    }
+}
+
+inline void service_ecc_error_intr() {return;}
+inline void service_ecc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        printf("bad ecc_notif_intr sts:%x\n", sts);
+        printf("%c", 0x1);
+    }
+}
+
+inline void service_hmac_error_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_HMAC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & HMAC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_KEY_MODE_ERROR_STS_MASK) {
+        *reg = HMAC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_KEY_MODE_ERROR_STS_MASK;
+        cptra_intr_rcv.hmac_error |= HMAC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_KEY_MODE_ERROR_STS_MASK;
+    }
+    if (sts & HMAC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_KEY_ZERO_ERROR_STS_MASK) {
+        *reg = HMAC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_KEY_ZERO_ERROR_STS_MASK;
+        cptra_intr_rcv.hmac_error |= HMAC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_KEY_ZERO_ERROR_STS_MASK;
+    }
+    if (sts & HMAC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR2_STS_MASK) {
+        *reg = HMAC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR2_STS_MASK;
+        cptra_intr_rcv.hmac_error |= HMAC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR2_STS_MASK;
+    }
+    if (sts & HMAC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR3_STS_MASK) {
+        *reg = HMAC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR3_STS_MASK;
+        cptra_intr_rcv.hmac_error |= HMAC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR3_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad hmac_error_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+inline void service_hmac_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        printf("bad hmac_notif_intr sts:%x\n", sts);
+        printf("%c", 0x1);
+    }
+}
+
+inline void service_kv_error_intr() {return;}
+inline void service_kv_notif_intr() {return;}
+inline void service_sha512_error_intr() {return;}
+inline void service_sha512_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        printf("bad sha512_notif_intr sts:%x\n", sts);
+        printf("%c", 0x1);
+    }
+}
+
+inline void service_sha256_error_intr() {return;}
+inline void service_sha256_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        printf("bad sha256_notif_intr sts:%x\n", sts);
+        printf("%c", 0x1);
+    }
+}
+
+inline void service_soc_ifc_error_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_WDT_TIMER1_TIMEOUT_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_WDT_TIMER1_TIMEOUT_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_WDT_TIMER2_TIMEOUT_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_WDT_TIMER2_TIMEOUT_STS_MASK;
+    }
+    if (sts == 0) {
+        printf("bad soc_ifc_error_intr sts:%x\n", sts);
+        printf("%c", 0x1);
+    }
+}
+
+inline void service_soc_ifc_notif_intr () {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+    }
+    if (sts == 0) {
+        printf("bad soc_ifc_notif_intr sts:%x\n", sts);
+        printf("%c", 0x1);
+    }
+}
+
+inline void service_sha512_acc_error_intr() {return;}
+inline void service_sha512_acc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        printf("bad sha512_acc_notif_intr sts:%x\n", sts);
+        printf("%c", 0x1);
+    }
+}
+
+inline void service_mldsa_error_intr() {return;}
+inline void service_mldsa_notif_intr() {return;}
+inline void service_axi_dma_error_intr() {return;}
+inline void service_axi_dma_notif_intr() {return;}
+
+
+#endif //CALIPTRA_ISR_H

--- a/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access/infinite_loop.s
+++ b/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access/infinite_loop.s
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "caliptra_defines.h"
+
+.set    mfdc, 0x7f9
+.set    mfdht, 0x7ce
+.set    mstatus, 0x300
+.set    mitcnt0, 0x7d2
+.set    mitb0, 0x7d3
+.set    mitctl0, 0x7d4
+.set    mie, 0x304
+.set    mpmc, 0x7c6
+
+// Code to execute
+.section .text
+.global _start
+_start:
+
+    // Enable Caches in MRAC
+    li      x1, 0xaaaaaaaa
+    csrw    0x7c0, x1
+
+    li      x3, 4
+    csrw    mfdc, x3        // disable store merging
+
+    // Set some register values
+    li      x1,  0x12345678
+    li      x2,  0xABCDEF00
+    li      x3,  0xCAFEBABA
+    li      x4,  0xDEADBEEF
+    li      x5,  0x05050505
+    li      x6,  0xA0A0A0A0
+    li      x7,  0x00FF00FF
+    li      x8,  0xCC00CC00
+    li      s1,  0xFEEDABED // Writing 0 to this register initiates CPU halt
+
+    // Simple infinite loop program with inner and outer loop
+    li      t3,  0
+outer:
+    addi    t3, t3, 1
+    li      t4, 123
+inner:
+    beq     s1, zero, halt_cpu
+    addi    t4, t4, -1
+    bne     t4, zero, inner
+    j       outer
+
+halt_cpu:
+    // Set mit0 and halt core
+    li      t5, 0xf0
+    li      t6, 0x20000800
+    csrwi   mitcnt0, 0x00   // Internal timer 0 counter
+    csrw    mitb0, t5       // Internal timer 0 boundary
+    csrwi   mitctl0, 0x01   // Internal timer 0 enable
+    csrw    mie, t6         // Internal timer 0 local interrupt enable
+    csrwi   mstatus, 0x08   // Internal timer 0 global interrupt enable
+    csrwi   mpmc, 0x03      // Initiate core halt with disable on mit0 interrupt
+    li      s1, 0xFEEDABED  // Indicate halt init
+    j       outer           // Return to infinite loop
+
+.section .dccm
+.global stdout
+stdout: .word STDOUT
+.global verbosity_g
+verbosity_g: .word 2
+
+.global intr_count
+intr_count: .word 0
+.global cptra_intr_rcv
+cptra_intr_rcv: .word 0

--- a/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access/mcu_jtag_mcu_sram.c
+++ b/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access/mcu_jtag_mcu_sram.c
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+#include "soc_address_map.h"
+#include "printf.h"
+#include "riscv_hw_if.h"
+#include "soc_ifc.h"
+#include "caliptra_ss_lc_ctrl_address_map.h"
+#include <string.h>
+#include <stdint.h>
+#include <time.h>
+#include <stdlib.h>
+
+volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
+
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+void main (void) {
+
+    VPRINTF(LOW, "=================\nHello World from MCU SRAM\n=================\n");
+
+    VPRINTF(LOW, "MCU: JTAG work is done\n");
+    
+    SEND_STDOUT_CTRL(0xff);
+
+    while(1);
+
+}

--- a/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access/mcu_jtag_mcu_sram.ld
+++ b/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access/mcu_jtag_mcu_sram.ld
@@ -1,0 +1,39 @@
+
+#********************************************************************************
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2020 Western Digital Corporation or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************************
+
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+
+SECTIONS {
+  
+  . = 0x21c00010;
+  .text   : { *(.text*) ; . = ALIGN(4); } =0x0000,
+  _text_end = .;
+  .rodata : { *(.rodata*) *(.srodata*) ; . = ALIGN(4); } =0x0000,
+  _rodata_end = .;
+
+  .dccm : { *(.dccm*) ; . = ALIGN(4); } =0x0000,
+  _dccm_end = .;
+  .data : { *(.data) *(.data.*) *(.sdata) *(.sdata.*) ; . = ALIGN(4); } =0x0000,
+  _data_end = .;
+  .bss : { *(.bss) *(.sbss) ; . = ALIGN(4); } =0x0000,
+  _bss_end = .;
+
+  STACK = ALIGN(16) + 0x1000;
+  ASSERT( STACK < 0x21C7FFFF, "ERROR: STACK allocation exceeds MCU SRAM Size 512KiB")
+}

--- a/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access/smoke_test_jtag_mcu_system_bus_access.c
+++ b/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access/smoke_test_jtag_mcu_system_bus_access.c
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/*
+    Run this test with the following command
+    submit_i ss_build -tc smoke_test_jtag_mcu_unlock -op -to 250000
+*/
+
+
+
+
+#include "soc_address_map.h"
+#include "printf.h"
+#include "riscv_hw_if.h"
+#include "soc_ifc.h"
+#include "caliptra_ss_lc_ctrl_address_map.h"
+#include <string.h>
+#include <stdint.h>
+#include <time.h>
+#include <stdlib.h>
+#include "caliptra_ss_lib.h"
+#include "fuse_ctrl.h"
+#include "lc_ctrl.h"
+
+volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
+
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+void main (void) {
+
+    uint32_t cptra_boot_go;
+
+    // Writing to Caliptra Boot GO register of MCI for CSS BootFSM to bring Caliptra out of reset 
+    // This is just to see CSSBootFSM running correctly
+    lsu_write_32(SOC_MCI_TOP_MCI_REG_CPTRA_BOOT_GO, 1);
+    VPRINTF(LOW, "MCU: Writing MCI SOC_MCI_TOP_MCI_REG_CALIPTRA_BOOT_GO\n");
+
+    cptra_boot_go = lsu_read_32(SOC_MCI_TOP_MCI_REG_CPTRA_BOOT_GO);
+    VPRINTF(LOW, "MCU: Reading SOC_MCI_TOP_MCI_REG_CALIPTRA_BOOT_GO %x\n", cptra_boot_go);
+
+    // Wait for ready_for_fuses
+    while(!(lsu_read_32(SOC_SOC_IFC_REG_CPTRA_FLOW_STATUS) & SOC_IFC_REG_CPTRA_FLOW_STATUS_READY_FOR_FUSES_MASK));
+    lcc_initialization();
+    transition_state(TEST_UNLOCKED0, raw_unlock_token[0], raw_unlock_token[1], raw_unlock_token[2], raw_unlock_token[3], 1);
+    reset_fc_lcc_rtl();
+
+    // Initialize fuses
+    lsu_write_32(SOC_SOC_IFC_REG_CPTRA_FUSE_WR_DONE, SOC_IFC_REG_CPTRA_FUSE_WR_DONE_DONE_MASK);
+    VPRINTF(LOW, "MCU: Set fuse wr done\n");
+
+    for (uint16_t ii = 0; ii < 1000; ii++) {
+        __asm__ volatile ("nop"); // Sleep loop as "nop"
+    }
+
+    //Sync phrase for JTAG
+    VPRINTF(LOW, "=================\n CALIPTRA_SS JTAG MCU Smoke Test with ROM \n=================\n\n");
+    VPRINTF(LOW, "MCU: waits until JTAG done\n");
+    while(1);
+}

--- a/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access/smoke_test_jtag_mcu_system_bus_access.tcl
+++ b/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access/smoke_test_jtag_mcu_system_bus_access.tcl
@@ -41,14 +41,17 @@ puts ""
 #enabling system bus for mem accesses
 riscv set_mem_access sysbus
 
+#Access MCU SRAM
+write_read_access "SRAM" 0x21c00000 8 {0x5a 0xa5}
+write_read_access "SRAM" 0x21c00000 16 {0x5a5a 0xa5a5}
+write_read_access "SRAM" 0x21c00000 32 {0x5a5a5a5a 0xa5a5a5a5}
+write_read_access "SRAM" 0x21c00000 64 {0x5a5a5a5a5a5a5a5a 0xa5a5a5a5a5a5a5a5}
+
 #Access DEBUG_OUT register
 write_read_access "DEBUG_OUT" 0x21000414 32 {0x7a7a7a7a 0x85858585}
 
 #Access DEBUG_IN register
 write_read_access "DEBUG_IN" 0x21000410 32 {0x7a7a7a7a 0x85858585}
-
-#Access MCU SRAM
-write_read_access "SRAM" 0x21c00000 64 {0x5a5a5a5a5a5a5a5a 0xa5a5a5a5a5a5a5a5}
 
 #test boot from MCI SRAM
 puts "Write HW override for sram execution"

--- a/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access/smoke_test_jtag_mcu_system_bus_access.tcl
+++ b/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access/smoke_test_jtag_mcu_system_bus_access.tcl
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+proc write_read_access {name address access_width patterns} {
+    foreach pattern $patterns {
+        write_memory $address $access_width $pattern phys
+        set actual [read_memory $address $access_width 1 phys ]
+        if {[compare $actual $pattern] != 0} {
+            puts "mismatch in $name!"
+            shutdown error
+        }
+    }
+}
+
+init
+
+set script_dir [file dirname [info script]]
+source [file join $script_dir .. libs jtag common.tcl]
+
+puts "Read Debug Module Status Register..."
+set val [riscv dmi_read $dmstatus_addr]
+puts "dmstatus: $val"
+if {($val & 0x00000c00) == 0} {
+    echo "The hart is halted!"
+    shutdown error
+}
+puts ""
+
+#enabling system bus for mem accesses
+riscv set_mem_access sysbus
+
+#Access DEBUG_OUT register
+write_read_access "DEBUG_OUT" 0x21000414 32 {0x7a7a7a7a 0x85858585}
+
+#Access DEBUG_IN register
+write_read_access "DEBUG_IN" 0x21000410 32 {0x7a7a7a7a 0x85858585}
+
+#Access MCU SRAM
+write_read_access "SRAM" 0x21c00000 64 {0x5a5a5a5a5a5a5a5a 0xa5a5a5a5a5a5a5a5}
+
+#test boot from MCI SRAM
+puts "Write HW override for sram execution"
+riscv dmi_write $MCI_DMI_MCI_HW_OVERRIDE 0x1
+set actual [riscv dmi_read  $MCI_DMI_MCI_HW_OVERRIDE]
+if {[compare $actual 0x1] != 0} {
+    puts "mismatch in register MCI_DMI_MCI_HW_OVERRIDE!"
+    shutdown error
+}
+puts "Setting reset vector to MCU SRAM"
+riscv dmi_write $MCI_DMI_MCU_RESET_VECTOR 0x21c00010
+puts "Setting reset request"
+riscv dmi_write $MCI_DMI_RESET_REQUEST 0x1
+
+shutdown

--- a/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access/smoke_test_jtag_mcu_system_bus_access.yml
+++ b/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access/smoke_test_jtag_mcu_system_bus_access.yml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+seed: 1
+testname: smoke_test_jtag_mcu_system_bus_access
+pre-exec: |
+  echo "Running pre_exec for [smoke_test_jtag_mcu_system_bus_access]"
+  CALIPTRA_ROOT=$CALIPTRA_SS_ROOT/third_party/caliptra-rtl make -f $CALIPTRA_SS_ROOT/third_party/caliptra-rtl/tools/scripts/Makefile CALIPTRA_INTERNAL_TRNG=0 TEST_DIR=$CALIPTRA_SS_ROOT/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access TESTNAME=infinite_loop program.hex
+  make -f $CALIPTRA_SS_ROOT/tools/scripts/Makefile TEST_DIR=$CALIPTRA_SS_ROOT/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access TESTNAME=smoke_test_jtag_mcu_system_bus_access mcu_program.hex
+  make -f $CALIPTRA_SS_ROOT/tools/scripts/Makefile TEST_DIR=$CALIPTRA_SS_ROOT/src/integration/test_suites/smoke_test_jtag_mcu_system_bus_access TESTNAME=mcu_jtag_mcu_sram mcu_lmem.hex


### PR DESCRIPTION
This merge request adds a new JTAG test that exercises JTAG to AXI path through VeeR's debug system bus access module.
Test accesses `DEBUG_[IN|OUT]` registers in the MCI using 32-bit data width.
It also accesses MCI SRAM using 64-bit data width, so that full AXI data width is covered in this test.