### PR TITLE
Update testplan

### DIFF
--- a/docs/testplan.hjson
+++ b/docs/testplan.hjson
@@ -1079,23 +1079,13 @@ Perform 64-bit access to MCI SRAM using JTAG to system bus path.
         smoke_test_wdt_rst
       ]
     }
-
     {
-      name: caliptra_ss_lcc_st_trans_cnt
+      name: caliptra_ss_lcc_volatile_unlock_cnt
       desc: "Exercise the second or following LCC state transition from LcStRaw to LcStTestUnlocked0. This test requires injecting an LCC transition counter for LcStRaw to simulated OTP memory followed by the request for a transition to LcStTestUnlocked0"
       stage: ""
       tests:
       [
         caliptra_ss_lcc_st_trans_cnt
-      ]
-    }
-    {
-      name: caliptra_ss_lc_st_trans_dummy
-      desc: "Allow LCC state transitions by writing 1 to TRANSITION_REGWEN followed by writing 0 to TRANSITION_CMD"
-      stage: ""
-      tests:
-      [
-        caliptra_ss_lc_st_trans_dummy
       ]
     }
     {
@@ -1126,21 +1116,12 @@ Perform 64-bit access to MCI SRAM using JTAG to system bus path.
       ]
     }
     {
-      name: caliptra_ss_lcc_alert_tap_dummy
-      desc: "Dummy alert injection. Write 0s to all fields of ALERT_TEST via TAP with one write command"
-      stage: ""
-      tests:
-      [
-        caliptra_ss_lcc_alert_tap_dummy
-      ]
-    }
-    {
-      name: caliptra_ss_lcc_token_hash_error
+      name: caliptra_ss_lcc_st_trans_kmac_err
       desc: "Test the LCC reaction to a transition token hashing error (KMAC error). Instruct LCC to perform state transitions while injecting (app_rsp[1].error = 1)"
       stage: ""
       tests:
       [
-        caliptra_ss_lcc_token_hash_error
+        caliptra_ss_lcc_st_trans_kmac_err
       ]
     }
   ]

--- a/docs/testplan.hjson
+++ b/docs/testplan.hjson
@@ -156,24 +156,6 @@
       ]
     }
     {
-      name: caliptra_ss_jtag_manuf_dbg
-      desc: ""
-      stage: ""
-      tests:
-      [
-        caliptra_ss_jtag_manuf_dbg
-      ]
-    }
-    {
-      name: caliptra_ss_jtag_uds_prog
-      desc: ""
-      stage: ""
-      tests:
-      [
-        caliptra_ss_jtag_uds_prog
-      ]
-    }
-    {
       name: caliptra_ss_lcc_alert
       desc: ""
       stage: ""
@@ -515,15 +497,6 @@ Either issue a SCRAP request or inject a state error, then verify that device li
       tests:
       [
         mcu_prod_rom_i3c_streaming_boot
-      ]
-    }
-    {
-      name: mcu_set_mci_cacheable
-      desc: ""
-      stage: ""
-      tests:
-      [
-        mcu_set_mci_cacheable
       ]
     }
     {
@@ -901,18 +874,6 @@ Perform 64-bit access to MCI SRAM using JTAG to system bus path.
       ]
     }
     {
-      name: smoke_test_mcu_mbox_axi_param
-      desc: ""
-      stage: ""
-      tests:
-      [
-        smoke_test_mcu_mbox1_axi_param
-        smoke_test_mcu_mbox0_axi_no_param
-        smoke_test_mcu_mbox1_axi_no_param
-        smoke_test_mcu_mbox0_axi_param
-      ]
-    }
-    {
       name: smoke_test_mcu_mbox_burst
       desc: ""
       stage: ""
@@ -943,16 +904,6 @@ Perform 64-bit access to MCI SRAM using JTAG to system bus path.
       ]
     }
     {
-      name: smoke_test_mcu_mbox_instantiation
-      desc: ""
-      stage: ""
-      tests:
-      [
-        smoke_test_mcu_mbox0_instantiation
-        smoke_test_mcu_mbox1_instantiation
-      ]
-    }
-    {
       name: smoke_test_mcu_mbox_invalid_axi
       desc: ""
       stage: ""
@@ -960,16 +911,6 @@ Perform 64-bit access to MCI SRAM using JTAG to system bus path.
       [
         smoke_test_mcu_mbox0_invalid_axi
         smoke_test_mcu_mbox1_invalid_axi
-      ]
-    }
-    {
-      name: smoke_test_mcu_mbox_pass_data
-      desc: ""
-      stage: ""
-      tests:
-      [
-        smoke_test_mcu_mbox1_pass_data
-        smoke_test_mcu_mbox0_pass_data
       ]
     }
     {

--- a/src/integration/test_suites/caliptra_ss_lcc_volatile_unlock/caliptra_ss_lcc_volatile_unlock_cnt.yml
+++ b/src/integration/test_suites/caliptra_ss_lcc_volatile_unlock/caliptra_ss_lcc_volatile_unlock_cnt.yml
@@ -1,8 +1,8 @@
 ---
 seed: 1
-testname: caliptra_ss_lcc_volatile_unlock
+testname: caliptra_ss_lcc_volatile_unlock_cnt
 pre-exec: |
-  echo "Running pre_exec for [caliptra_ss_lcc_volatile_unlock]"
+  echo "Running pre_exec for [caliptra_ss_lcc_volatile_unlock_cnt]"
   echo "Generate predefined LC start state and LC counter value."
   rm -rf otp-img.2048.vmem
   # Raw with non-0 count, to cover a corner case


### PR DESCRIPTION
This MR updates the testplan.
Some tests were removed based on waivers available in the upstream CSS v2.0.2
https://github.com/chipsalliance/caliptra-ss/blob/css-v2.0.2/.github/workflow_metadata/unused_tests_waiver.txt

The rest of the tests were removed as they were combined with already existing tests.
2 tests were renamed to align testpoint names with tests' names.